### PR TITLE
Add Age Suitability page

### DIFF
--- a/age-suitability.html
+++ b/age-suitability.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Age Suitability</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial; max-width: 800px; margin: 0 auto; padding: 40px 20px; line-height: 1.6; color: #222; }
+    h1, h2 { color: #111; }
+  </style>
+</head>
+<body>
+  <h1>Age Suitability</h1>
+  <p>TapTrust does not contain explicit content, imagery, or language. However, because the app’s purpose is to verify identification in contexts that include age-restricted services such as alcohol sales, we have set the suitability rating to 18+.</p>
+  <p>We chose the higher threshold to reflect the nature of ID verification and to align with best practices for apps connected to regulated activities. This ensures clear expectations for both businesses and users.</p>
+  <footer>
+    <p>© 2025 Ian Deuberry. All rights reserved.</p>
+  </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@
         <a href="privacy.html">Privacy Policy</a>
         <a href="index.html">Support</a>
         <a href="terms.html">Terms of Service</a>
+        <a href="age-suitability.html">Age Suitability</a>
       </div>
       <div style="margin-top:10px;">
         © 2025 Ian Deuberry. TapTrust is not affiliated with Apple.  


### PR DESCRIPTION
## Summary
- add a standalone Age Suitability page describing the app's rating rationale
- link to the new page from the support footer navigation

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68c9b620f7bc8330aeaffdd1b815ee3d